### PR TITLE
Task Endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,13 @@
 # cs565-backend (under construction)
 
-Backend for our CS 565 project (name pending).
+Backend for our crowdsourced optical music recognition project (name pending).
 
 ## Contents
 
 - [API Documentation](#api-documentation)
+- [API Usage for Frontend](#api-usage-for-frontend)
 - [Development Environment Setup](#development-environment-setup)
+- [Running the Server](#running-the-server)
 
 ## API Documentation
 
@@ -64,6 +66,8 @@ These are the following endpoints available:
 |            | PUT     | Replace entire measures with supplied measures or 404 error |
 |            | DELETE  | Delete specified measures or 404 error                  |
 | lilypond/:id | GET   | WIP                                                     |
+| measuretask | GET    | Get the next measure to be digitized                    |
+| measureresponse | POST | Add a digitization for the given measure              |
 
 ### Query Parameters
 
@@ -77,6 +81,110 @@ Additionally, the API has the following JSON encoded query string parameters for
 | skip     | specify the number of results to skip in the result set; useful for pagination               |
 | limit    | specify the number of results to return (default should be 100 for tasks and unlimited for users)                    |
 | count    | if set to true, return the count of documents that match the query (instead of the documents themselves)                    |
+
+## API Usage for Frontend
+Below gives examples of (some of) the endpoints that will be used in the frontend.
+
+### Adding a new user
+`POST` request to `<endpoint>/api/users` with the following JSON body:
+```json
+{
+    // note that email is an optional field, in which case you could just send an empty body
+    // emails are required to be unique
+    "email": "thisisatestemail1@test.com"
+}
+```
+
+This returns something like the following:
+```json
+{
+    "message": "User successfully created",
+    "result": {
+        "email": "thisisatestemail1@test.com",
+        "_id": "644b77f8db4b011282fccd45",
+        "__v": 0
+    }
+}
+```
+
+### Retrieving a task
+`GET` request to `<endpoint>/api/measuretask`, no JSON body needed.
+
+This returns something like the following:
+```json
+{
+    "message": "Measure task GET successful!",
+    "data": {
+        "_id": "644b75053f4ea5e40af28956",
+        "image": {
+            "type": "Buffer",
+            // base64 encoded image of the measure
+            "data": [105, 86, ...]
+        }
+    }
+}
+```
+
+### Submitting a task response
+`POST` request to `<endpoint>/api/measureresponse` with the following JSON body:
+```json
+{
+    // Object ID of the measure, from the previous endpoint
+    "measureId": "644b75053f4ea5e40af28956",
+    "measureResponse": {
+        // Object ID of the current user
+        "userId": "6441711a168095d6fe7d479f",
+        // Array of symbols according to our Symbol objects.
+        "symbols": [
+            {
+                "name": "quarter_note",
+                "pitch": 9
+            },
+            {
+                "name": "half_note",
+                "pitch": 3
+            },
+            {
+                "name": "quarter_rest"
+            }
+        ]
+    }
+}
+```
+
+This returns something like the following:
+```json
+{
+    "message": "MeasureResponse POST successful!",
+    "data": {
+        "_id": "644b75053f4ea5e40af28956",
+        "sheetId": "644b75043f4ea5e40af28954",
+        "measureNum": 1,
+        "responses": [
+            {
+                "userId": "6441711a168095d6fe7d479f",
+                "symbols": [
+                    {
+                        "name": "quarter_note",
+                        "pitch": 9,
+                        "_id": "644b790fdb4b011282fccd48"
+                    },
+                    {
+                        "name": "half_note",
+                        "pitch": 3,
+                        "_id": "644b790fdb4b011282fccd49"
+                    },
+                    {
+                        "name": "quarter_rest",
+                        "_id": "644b790fdb4b011282fccd4a"
+                    }
+                ],
+                "_id": "644b790fdb4b011282fccd47"
+            }
+        ]
+    }
+}
+```
 
 ## Development Environment Setup
 
@@ -148,6 +256,4 @@ To run the server in "production":
 npx run build && npm start
 ```
 
-<!-- TODO: setup MongoDB -->
-<!-- TODO: setup Heroku -->
-<!-- TODO: auto-deploy to Heroku -->
+The repository is configured in such a way that any updates to the `main` branch will automatically be linted and then deployed to Heroku via CI.

--- a/README.md
+++ b/README.md
@@ -29,7 +29,6 @@ Measure:
 | measureNum | number | ✓ | ✘ | - | number of measure within sheet for ordering |
 | image | Buffer | ✓ | ✓ | - | base64 encoded image of measure, only support single image |
 | responses | [MeasureResponse] | ✘ | ✘ | [] | stores crowdworker digitizations of measure |
-| responseCount | number | ✘ | ✘ | 0 | stores the number of responses (easier queries via sorting) |
 
 MeasureResponse:
 | Field | Type | Required | Unique | Default | Notes |

--- a/src/models/measure.ts
+++ b/src/models/measure.ts
@@ -6,15 +6,13 @@ interface Measure {
   measureNum: number
   image: Buffer
   responses: [MeasureResponse]
-  responseCount: number
 }
 
 const measureSchema: Schema = new Schema<Measure>({
   sheetId: { type: Schema.Types.ObjectId, required: [true, 'sheetId is required'] },
   measureNum: { type: Number, required: [true, 'measureNum is required'] },
   image: { type: Buffer, required: [true, 'image binary data is required'] },
-  responses: { type: [{ type: MeasureResponseSchema }], default: [] },
-  responseCount: { type: Number, default: 0 }
+  responses: { type: [{ type: MeasureResponseSchema }], default: [] }
 });
 
 const MeasureModel = model<Measure>('Measure', measureSchema);

--- a/src/routes/index.ts
+++ b/src/routes/index.ts
@@ -8,6 +8,7 @@ import measuresRoute from './measures';
 import measuresIdRoute from './measures-id';
 import lilypondRoute from './lilypond';
 import measureResponseRoute from './measureresponse';
+import measureTaskRoute from './measuretask';
 
 const registerRoutes = (server: Application, router: Router): void => {
   server.use('/api', sheetsRoute(router));
@@ -16,8 +17,9 @@ const registerRoutes = (server: Application, router: Router): void => {
   server.use('/api', usersIdRoutes(router));
   server.use('/api', measuresRoute(router));
   server.use('/api', measuresIdRoute(router));
-  server.use('/api', measureResponseRoute(router));
   server.use('/api', lilypondRoute(router));
+  server.use('/api', measureResponseRoute(router));
+  server.use('/api', measureTaskRoute(router));
 };
 
 export default registerRoutes;

--- a/src/routes/index.ts
+++ b/src/routes/index.ts
@@ -7,6 +7,7 @@ import usersIdRoutes from './users-id';
 import measuresRoute from './measures';
 import measuresIdRoute from './measures-id';
 import lilypondRoute from './lilypond';
+import measureResponseRoute from './measureresponse';
 
 const registerRoutes = (server: Application, router: Router): void => {
   server.use('/api', sheetsRoute(router));
@@ -15,6 +16,7 @@ const registerRoutes = (server: Application, router: Router): void => {
   server.use('/api', usersIdRoutes(router));
   server.use('/api', measuresRoute(router));
   server.use('/api', measuresIdRoute(router));
+  server.use('/api', measureResponseRoute(router));
   server.use('/api', lilypondRoute(router));
 };
 

--- a/src/routes/measureresponse.ts
+++ b/src/routes/measureresponse.ts
@@ -1,0 +1,27 @@
+import { type Request, type Response, type Router } from 'express';
+import MeasureModel from '../models/measure';
+
+const measureResponseRoute = (router: Router): Router => {
+  router.post('/measureresponse', async (req: Request, res: Response) => {
+    try {
+      if (!('measureId' in req.body)) {
+        res.status(400).json({ message: 'MeasureResponse POST failed - validation error', data: '_id is required' });
+        return;
+      }
+
+      if (!('measureResponse' in req.body)) {
+        res.status(400).json({ message: 'MeasureResponse POST failed - validation error', data: 'measureResponse is required' });
+        return;
+      }
+
+      const result = await MeasureModel.findByIdAndUpdate(req.body.measureId, { $push: { responses: req.body.measureResponse } }, { returnDocument: 'after', select: '_id sheetId measureNum responses' });
+      res.status(201).json({ message: 'MeasureResponse POST successful!', data: result });
+    } catch (error) {
+      res.status(500).json({ message: 'MeasureResponse POST failed - something went wrong on the server', data: error });
+    }
+  });
+
+  return router;
+};
+
+export default measureResponseRoute;

--- a/src/routes/measures-id.ts
+++ b/src/routes/measures-id.ts
@@ -19,10 +19,6 @@ const measuresIdRoute = (router: Router): Router => {
   // Update a Measure by ID
   router.put('/measures/:id', async (req: Request, res: Response) => {
     try {
-      if ('responseCount' in req.body) {
-        req.body.responseCount = req.body.responses.length;
-      }
-
       const measureId = req.params.id;
       const updatedMeasure = await MeasureModel.findByIdAndUpdate(measureId, req.body, { new: true });
       res.status(200).json({ message: 'Measure updated successfully', data: updatedMeasure });

--- a/src/routes/measures.ts
+++ b/src/routes/measures.ts
@@ -7,10 +7,6 @@ const measuresRoute = (router: Router): Router => {
   // Create a new Measure
   router.post('/measures', async (req: Request, res: Response) => {
     try {
-      if ('responseCount' in req.body) {
-        req.body.responseCount = req.body.responses.length;
-      }
-
       const newMeasure = await MeasureModel.create(req.body);
       res.status(201).json({ message: 'Measure created successfully', data: newMeasure });
     } catch (error) {

--- a/src/routes/measuretask.ts
+++ b/src/routes/measuretask.ts
@@ -4,7 +4,7 @@ import MeasureModel from '../models/measure';
 const measureTaskRoute = (router: Router): Router => {
   router.get('/measuretask', async (req: Request, res: Response) => {
     try {
-      const measures = await MeasureModel.find().select('_id responses');
+      const measures = await MeasureModel.find().select('_id sheetId measureNum responses');
 
       if (measures.length === 0) {
         res.status(400).json({ message: 'Measure task GET failed - no measures present on server', data: '' });
@@ -13,7 +13,26 @@ const measureTaskRoute = (router: Router): Router => {
 
       // sort from least number of responses to most
       const sortedMeasures = measures.sort((measure1, measure2) => {
-        return measure1.responses.length <= measure2.responses.length ? -1 : 1;
+        // focus on least responses
+        if (measure1.responses.length < measure2.responses.length) {
+          return -1;
+        } else if (measure1.responses.length > measure2.responses.length) {
+          return 1;
+        }
+
+        // tiebreak by sheetId
+        if (measure1.sheetId < measure2.sheetId) {
+          return -1;
+        } else if (measure1.sheetId > measure2.sheetId) {
+          return 1;
+        }
+
+        // tiebreak by measureNum
+        if (measure1.measureNum <= measure2.measureNum) {
+          return -1;
+        }
+
+        return 1;
       });
 
       // retrieve the measure with the least responses

--- a/src/routes/measuretask.ts
+++ b/src/routes/measuretask.ts
@@ -1,0 +1,31 @@
+import { type Request, type Response, type Router } from 'express';
+import MeasureModel from '../models/measure';
+
+const measureTaskRoute = (router: Router): Router => {
+  router.get('/measuretask', async (req: Request, res: Response) => {
+    try {
+      const measures = await MeasureModel.find().select('_id responses');
+
+      if (measures.length === 0) {
+        res.status(400).json({ message: 'Measure task GET failed - no measures present on server', data: '' });
+        return;
+      }
+
+      // sort from least number of responses to most
+      const sortedMeasures = measures.sort((measure1, measure2) => {
+        return measure1.responses.length <= measure2.responses.length ? -1 : 1;
+      });
+
+      // retrieve the measure with the least responses
+      const taskMeasure = await MeasureModel.findById(sortedMeasures[0]._id).select('_id image');
+
+      res.status(200).json({ message: 'Measure task GET successful!', data: taskMeasure });
+    } catch (error) {
+      res.status(500).json({ message: 'Measure task GET failed - something went wrong on the server', data: error });
+    }
+  });
+
+  return router;
+};
+
+export default measureTaskRoute;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -106,5 +106,5 @@
     // "skipDefaultLibCheck": true,                      /* Skip type checking .d.ts files that are included with TypeScript. */
     "skipLibCheck": true                                 /* Skip type checking all .d.ts files. */
   },
-  "include": ["src/*"]
+  "include": ["src/**/*"]
 }


### PR DESCRIPTION
- `/api/measuretask` endpoint for easy retrieval of next measure to be processed
- `/api/measureresponse` endpoint for pushing measure responses to the database
- refactored out responseCount field, backend should be robust to concurrent response submissions
- added examples of API for frontend to README